### PR TITLE
print help when used with no options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,11 @@ mod plot;
 mod pretty;
 mod sample;
 
-use bpaf::{Bpaf, Parser};
+use bpaf::Bpaf;
 
 /// Tools for comparative benchmarking
 #[derive(Bpaf)]
+#[bpaf(options, fallback_to_usage)]
 enum Subcommand {
     Sample(#[bpaf(external(sample::options))] sample::Options),
     Analyze(#[bpaf(external(analyze::options))] analyze::Options),


### PR DESCRIPTION
```
elakelaiset% cargo run                                                                                                                                                                                                          
   Compiling cbdr v0.2.4 (/home/pacak/github/cbdr)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s
     Running `target/debug/cbdr`
Tools for comparative benchmarking

Usage: cbdr COMMAND ...

Available options:
    -h, --help  Prints help information

Available commands:
    sample      Repeatedly runs benchmarks chosen at random and prints results as CSV
    analyze     For each pair of benchmarks (x and y), shows, for each metric (x̄
    plot        Takes CSV data on stdin and produces a vega-lite plot specification on stdout

```